### PR TITLE
Add dnwm: CDEPS data component for NWM river discharge (one-way NWM to OCN)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ endif()
 target_include_directories(dshr PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/streams>
                                        $<INSTALL_INTERFACE:mod>)
 
-foreach(COMP datm dice dglc dlnd docn drof dwav)
+foreach(COMP datm dice dglc dlnd docn drof dwav dnwm)
   add_subdirectory("${COMP}")
   if(BLD_STANDALONE)
     target_include_directories(${COMP} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/share>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ endif()
 target_include_directories(dshr PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/streams>
                                        $<INSTALL_INTERFACE:mod>)
 
-foreach(COMP datm dice dglc dlnd docn drof dwav dnwm)
+foreach(COMP datm dice dglc dlnd docn drof dnwm dwav)
   add_subdirectory("${COMP}")
   if(BLD_STANDALONE)
     target_include_directories(${COMP} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/share>

--- a/dnwm/CMakeLists.txt
+++ b/dnwm/CMakeLists.txt
@@ -1,0 +1,33 @@
+project(dnwm Fortran)
+set(SRCFILES  nwm_comp_nuopc.F90)
+
+foreach(FILE ${SRCFILES})
+  if(EXISTS "${CASEROOT}/SourceMods/src.dnwm/${FILE}")
+    list(REMOVE_ITEM SRCFILES ${FILE})
+    list(APPEND SRCFILES "${CASEROOT}/SourceMods/src.dnwm/${FILE}")
+    message("Using ${FILE} from ${CASEROOT}/SourceMods/src.dnwm")
+  endif()
+endforeach()
+
+message("DNWM srcfiles are ${SRCFILES}")
+
+add_library(dnwm ${SRCFILES})
+
+add_dependencies(dnwm dshr streams)
+target_include_directories (dnwm PRIVATE ${ESMF_F90COMPILEPATHS})
+target_include_directories (dnwm PRIVATE "${CMAKE_SOURCE_DIR}")
+target_include_directories (dnwm PRIVATE "${PIO_Fortran_INCLUDE_DIR}")
+if(NOT DISABLE_FoX)
+target_include_directories (dnwm PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../fox/include)
+endif()
+
+if(BLD_STANDALONE)
+  # ESMX requires mod files
+  foreach (SRC ${SRCFILES})
+    string(REGEX REPLACE "[.]F90$" ".mod" MOD ${SRC})
+    if (NOT DEFINED CIMEROOT AND MOD STREQUAL nwm_comp_nuopc.mod)
+      set(MOD cdeps_dnwm_comp.mod)
+    endif()
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${MOD}" DESTINATION include)
+  endforeach ()
+endif()

--- a/dnwm/nwm_comp_nuopc.F90
+++ b/dnwm/nwm_comp_nuopc.F90
@@ -397,13 +397,18 @@ contains
     call NUOPC_ModelGet(gcomp, modelClock=clock, importState=importState, exportState=exportState, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! For nuopc - the component clock is advanced at the end of the time interval
-    ! For these to match for now - need to advance nuopc one timestep ahead for
-    ! shr_strdata time interpolation
-    call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep, rc=rc)
+    ! One-way direct NWM->OCN connector: there is no CMEPS mediator to broker time.
+    ! SCHISM applies the imported discharge as a zero-order hold over its current
+    ! step [currTime, currTime+dt] and the export is stamped with currTime (below),
+    ! so interpolate the stream AT currTime -- not currTime+timeStep. The CDEPS dshr
+    ! default reads one step ahead because the mediator schedule consumes the data at
+    ! a later phase; on this mediator-less route that lead would inject the NEXT
+    ! interval's flow one step early -- invisible to a constant-discharge test, but a
+    ! ramping hydrograph would show the offset. Reading currTime keeps the exported
+    ! value consistent with its currTime stamp.
+    call ESMF_ClockGet( clock, currTime=currTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    nextTime = currTime + timeStep
-    call ESMF_TimeGet( nextTime, yy=yr, mm=mon, dd=day, s=next_tod, rc=rc )
+    call ESMF_TimeGet( currTime, yy=yr, mm=mon, dd=day, s=next_tod, rc=rc )
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call shr_cal_ymd2date(yr, mon, day, next_ymd)
 

--- a/dnwm/nwm_comp_nuopc.F90
+++ b/dnwm/nwm_comp_nuopc.F90
@@ -1,0 +1,524 @@
+#ifdef CESMCOUPLED
+module nwm_comp_nuopc
+#else
+module cdeps_dnwm_comp
+#endif
+
+  !----------------------------------------------------------------------------
+  ! This is the NUOPC cap for DNWM (data National Water Model river component).
+  !
+  ! Cloned from the DROF (data runoff) cap. Unlike DROF, which exports gridded
+  ! runoff (Forr_rofl/Forr_rofi in kg m-2 s-1), DNWM exports a single field
+  ! `river_volume_flux` carrying VOLUMETRIC discharge in m3 s-1, per source
+  ! element, intended for one-way NWM -> SCHISM forcing. The reach->element
+  ! pairing is done offline; DNWM's stream supplies per-element discharge on the
+  ! SCHISM element mesh, and the connector to SCHISM is a redistribution (no
+  ! gridded area-flux regrid). Mirrors DROF's datamode='copyall' passthrough.
+  !----------------------------------------------------------------------------
+  use ESMF             , only : ESMF_VM, ESMF_VMBroadcast, ESMF_GridCompGet
+  use ESMF             , only : ESMF_Mesh, ESMF_GridComp, ESMF_Time, ESMF_TimeInterval
+  use ESMF             , only : ESMF_State, ESMF_Clock, ESMF_SUCCESS, ESMF_LOGMSG_INFO
+  use ESMF             , only : ESMF_TraceRegionEnter, ESMF_TraceRegionExit
+  use ESMF             , only : ESMF_Alarm, ESMF_METHOD_INITIALIZE, ESMF_MethodAdd, ESMF_MethodRemove
+  use ESMF             , only : ESMF_TimeGet, ESMF_ClockGet, ESMF_GridCompSetEntryPoint
+  use ESMF             , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
+  use ESMF             , only : operator(+), ESMF_LogWrite
+  use ESMF             , only : ESMF_StateGet, ESMF_StateItem_Flag, ESMF_STATEITEM_FIELD, operator(==)
+  use NUOPC            , only : NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
+  use NUOPC            , only : NUOPC_CompAttributeGet, NUOPC_Advertise, NUOPC_IsConnected
+  use NUOPC            , only : NUOPC_FieldDictionaryHasEntry, NUOPC_FieldDictionaryAddEntry
+  use NUOPC_Model      , only : model_routine_SS        => SetServices
+  use NUOPC_Model      , only : model_label_Advance     => label_Advance
+  use NUOPC_Model      , only : model_label_SetRunClock => label_SetRunClock
+  use NUOPC_Model      , only : model_label_Finalize    => label_Finalize
+  use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
+  use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
+  use shr_const_mod    , only : SHR_CONST_SPVAL
+  use shr_cal_mod      , only : shr_cal_ymd2date
+  use shr_log_mod      , only : shr_log_setLogUnit, shr_log_error
+  use dshr_methods_mod , only : dshr_state_getfldptr, dshr_state_diagnose, chkerr, memcheck
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_advance, shr_strdata_get_stream_domain
+  use dshr_strdata_mod , only : shr_strdata_init_from_config
+  use dshr_mod         , only : dshr_model_initphase, dshr_init
+  use dshr_mod         , only : dshr_state_setscalar, dshr_set_runclock, dshr_check_restart_alarm
+  use dshr_mod         , only : dshr_restart_read, dshr_restart_write, dshr_mesh_init
+  use dshr_dfield_mod  , only : dfield_type, dshr_dfield_add, dshr_dfield_copy
+  use dshr_fldlist_mod , only : fldlist_type, dshr_fldlist_add, dshr_fldlist_realize
+  use nuopc_shr_methods, only : shr_get_rpointer_name
+
+  implicit none
+  private ! except
+
+  public  :: SetServices
+  public  :: SetVM
+  private :: InitializeAdvertise
+  private :: InitializeRealize
+  private :: ModelAdvance
+  private :: dnwm_comp_run
+  private :: ModelFinalize
+
+  !--------------------------------------------------------------------------
+  ! Private module data
+  !--------------------------------------------------------------------------
+
+  type(shr_strdata_type)       :: sdat
+  type(ESMF_Mesh)              :: model_mesh                          ! model mesh
+  character(len=CS)            :: flds_scalar_name = ''
+  integer                      :: flds_scalar_num = 0
+  integer                      :: flds_scalar_index_nx = 0
+  integer                      :: flds_scalar_index_ny = 0
+  integer                      :: mpicom                              ! mpi communicator
+  integer                      :: my_task                             ! my task in mpi communicator mpicom
+  logical                      :: mainproc                          ! true of my_task == main_task
+  character(len=16)            :: inst_suffix = ""                    ! char string associated with instance (ie. "_0001" or "")
+  integer                      :: logunit                             ! logging unit number
+  logical                      :: restart_read
+  character(CL)                :: case_name                           ! case name
+  character(*) , parameter     :: nullstr = 'null'
+                                                                      ! dnwm_in namelist input
+  character(CL)                :: streamfilename = nullstr            ! filename to obtain stream info from
+  character(CL)                :: nlfilename = nullstr                ! filename to obtain namelist info from
+  character(CL)                :: dataMode = nullstr                  ! flags physics options wrt input data
+  character(CL)                :: model_meshfile = nullstr            ! full pathname to model meshfile
+  character(CL)                :: model_maskfile = nullstr            ! full pathname to obtain mask from
+  character(CL)                :: restfilm = nullstr                  ! model restart file namelist
+  integer                      :: nx_global
+  integer                      :: ny_global
+  logical                      :: skip_restart_read = .false.         ! true => skip restart read
+  logical                      :: export_all = .false.                ! true => export all fields, do not check connected or not
+
+  logical                      :: diagnose_data = .true.
+  integer      , parameter     :: main_task=0                       ! task number of main task
+#ifdef CESMCOUPLED
+  character(*) , parameter     :: modName =  "(nwm_comp_nuopc)"
+#else
+  character(*) , parameter     :: modName =  "(cdeps_dnwm_comp)"
+#endif
+
+  ! Exported field: volumetric river discharge [m3 s-1], per source element.
+  character(*) , parameter     :: fldname_river = 'river_volume_flux'
+
+  ! linked lists
+  type(fldList_type) , pointer :: fldsExport => null()
+  type(dfield_type)  , pointer :: dfields    => null()
+
+  ! model mask and model fraction
+  real(r8), pointer            :: model_frac(:) => null()
+  integer , pointer            :: model_mask(:) => null()
+
+  ! module pointer arrays
+  real(r8), pointer            :: river_volume_flux(:) => null()
+
+  character(*) , parameter     :: u_FILE_u = &
+       __FILE__
+
+!===============================================================================
+contains
+!===============================================================================
+
+  subroutine SetServices(gcomp, rc)
+    type(ESMF_GridComp)  :: gcomp
+    integer, intent(out) :: rc
+
+    ! Local varaibles
+    character(len=*),parameter  :: subname=trim(modName)//':(SetServices) '
+    !--------------------------------
+
+    rc = ESMF_SUCCESS
+    call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO)
+
+    ! the NUOPC gcomp component will register the generic methods
+    call NUOPC_CompDerive(gcomp, model_routine_SS, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! switching to IPD versions
+    call ESMF_GridCompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
+         userRoutine=dshr_model_initphase, phase=0, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    ! set entry point for methods that require specific implementation
+    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
+         phaseLabelList=(/"IPDv01p1"/), userRoutine=InitializeAdvertise, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
+         phaseLabelList=(/"IPDv01p3"/), userRoutine=InitializeRealize, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! attach specializing method(s)
+    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Advance, specRoutine=ModelAdvance, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_MethodRemove(gcomp, label=model_label_SetRunClock, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_SetRunClock, specRoutine=dshr_set_runclock, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Finalize, specRoutine=ModelFinalize, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO)
+
+  end subroutine SetServices
+
+  !===============================================================================
+
+  subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
+    use shr_nl_mod, only:  shr_nl_find_group_name
+    ! input/output variables
+    type(ESMF_GridComp)  :: gcomp
+    type(ESMF_State)     :: importState, exportState
+    type(ESMF_Clock)     :: clock
+    integer, intent(out) :: rc
+
+    ! local variables
+    integer           :: inst_index ! number of current instance (ie. 1)
+    integer           :: nu         ! unit number
+    integer           :: ierr       ! error code
+    type(fldlist_type), pointer :: fldList
+    type(ESMF_VM)     :: vm
+    integer :: bcasttmp(4)
+    character(len=*),parameter :: subname=trim(modName)//':(InitializeAdvertise) '
+    character(*)    ,parameter :: F00 = "('(" // trim(modName) // ") ',8a)"
+    character(*)    ,parameter :: F01 = "('(" // trim(modName) // ") ',a,2x,i8)"
+    character(*)    ,parameter :: F02 = "('(" // trim(modName) // ") ',a,l6)"
+    !-------------------------------------------------------------------------------
+
+    namelist / dnwm_nml / datamode, model_meshfile, model_maskfile, &
+         restfilm, nx_global, ny_global, skip_restart_read, export_all
+
+    rc = ESMF_SUCCESS
+
+    call NUOPC_CompAttributeGet(gcomp, name='case_name', value=case_name, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Obtain flds_scalar values, mpi values, multi-instance values and
+    ! set logunit and set shr logging to my log file. DNWM plays the runoff
+    ! (ROF) role in the coupled system, so reuse the 'ROF' component string.
+    call dshr_init(gcomp, 'ROF', mpicom, my_task, inst_index, inst_suffix, &
+         flds_scalar_name, flds_scalar_num, flds_scalar_index_nx, flds_scalar_index_ny, &
+         logunit, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! determine logical mainproc
+    mainproc = (my_task == main_task)
+
+    ! Read dnwm_nml from nlfilename
+    if (mainproc) then
+       nlfilename = "dnwm_in"//trim(inst_suffix)
+       open (newunit=nu,file=trim(nlfilename),status="old",action="read")
+       call shr_nl_find_group_name(nu, 'dnwm_nml', status=ierr)
+       read (nu,nml=dnwm_nml,iostat=ierr)
+       close(nu)
+       if (ierr > 0) then
+          rc = ierr
+          call shr_log_error(subName//': namelist read error '//trim(nlfilename), rc=rc)
+          return
+       end if
+
+       ! write namelist input to standard out
+       write(logunit,F00)' datamode       = ',trim(datamode)
+       write(logunit,F00)' model_meshfile = ',trim(model_meshfile)
+       write(logunit,F00)' model_maskfile = ',trim(model_maskfile)
+       write(logunit,F01)' nx_global = ',nx_global
+       write(logunit,F01)' ny_global = ',ny_global
+       write(logunit,F00)' restfilm = ',trim(restfilm)
+       write(logunit,F02)' skip_restart_read = ',skip_restart_read
+       write(logunit,F02)' export_all = ', export_all
+       bcasttmp = 0
+       bcasttmp(1) = nx_global
+       bcasttmp(2) = ny_global
+       if(skip_restart_read) bcasttmp(3) = 1
+       if(export_all) bcasttmp(4) = 1
+    end if
+
+    ! broadcast namelist input
+    call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    call ESMF_VMBroadcast(vm, datamode, CL, main_task, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_VMBroadcast(vm, model_meshfile, CL, main_task, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_VMBroadcast(vm, model_maskfile, CL, main_task, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_VMBroadcast(vm, restfilm, CL, main_task, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_VMBroadcast(vm, bcasttmp, 4, main_task, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    nx_global = bcasttmp(1)
+    ny_global = bcasttmp(2)
+    skip_restart_read = (bcasttmp(3) == 1)
+    export_all = (bcasttmp(4) == 1)
+
+    ! Validate datamode
+    if (trim(datamode) == 'copyall') then
+       if (mainproc) write(logunit,*) 'dnwm datamode = ',trim(datamode)
+    else
+       call shr_log_error(' ERROR illegal dnwm datamode = '//trim(datamode), rc=rc)
+       return
+    end if
+
+    ! river_volume_flux is not a CF/standard NUOPC field; register it (m3 s-1
+    ! volumetric discharge) so it can be advertised, realized and connected.
+    if (.not. NUOPC_FieldDictionaryHasEntry(trim(fldname_river), rc=rc)) then
+       call NUOPC_FieldDictionaryAddEntry(trim(fldname_river), "m3 s-1", rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
+
+    call dshr_fldList_add(fldsExport, trim(flds_scalar_name))
+    call dshr_fldlist_add(fldsExport, trim(fldname_river))
+
+    fldlist => fldsExport ! the head of the linked list
+    do while (associated(fldlist))
+       call NUOPC_Advertise(exportState, standardName=fldlist%stdname, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call ESMF_LogWrite('(dnwm_comp_advertise): Fr_nwm '//trim(fldList%stdname), ESMF_LOGMSG_INFO)
+       fldList => fldList%next
+    enddo
+
+  end subroutine InitializeAdvertise
+
+  !===============================================================================
+  subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
+
+    ! input/output variables
+    type(ESMF_GridComp)  :: gcomp
+    type(ESMF_State)     :: importState, exportState
+    type(ESMF_Clock)     :: clock
+    integer, intent(out) :: rc
+
+    ! local variables
+    type(ESMF_TIME) :: currTime
+    type(ESMF_StateItem_Flag) :: itemtype_scalar  ! presence of cpl_scalars in exportState
+    integer         :: current_ymd  ! model date
+    integer         :: current_year ! model year
+    integer         :: current_mon  ! model month
+    integer         :: current_day  ! model day
+    integer         :: current_tod  ! model sec into model date
+    character(len=*), parameter :: F00   = "('" // trim(modName) // ": ')',8a)"
+    character(len=*), parameter :: subname=trim(modName)//':(InitializeRealize) '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    ! Initialize mesh, restart flag, logunit
+    call ESMF_TraceRegionEnter('dnwm_strdata_init')
+    call dshr_mesh_init(gcomp, sdat, nullstr, logunit, 'ROF', nx_global, ny_global, &
+         model_meshfile, model_maskfile, model_mesh, model_mask, model_frac, restart_read, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Initialize stream data type
+    streamfilename = 'dnwm.streams'//trim(inst_suffix)
+#ifndef DISABLE_FOX
+    streamfilename = trim(streamfilename)//'.xml'
+#endif
+    call shr_strdata_init_from_config(sdat, streamfilename, model_mesh, clock, 'ROF', logunit, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_TraceRegionExit('dnwm_strdata_init')
+
+    ! NUOPC_Realize "realizes" a previously advertised field in the importState and exportState
+    ! by replacing the advertised fields with the newly created fields of the same name.
+    call dshr_fldlist_realize( exportState, fldsExport, flds_scalar_name, flds_scalar_num, model_mesh, &
+         subname//':dnwmExport', export_all, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Get the time to interpolate the stream data to
+    call ESMF_ClockGet(clock, currTime=currTime, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_TimeGet(currTime, yy=current_year, mm=current_mon, dd=current_day, s=current_tod, rc=rc )
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_cal_ymd2date(current_year, current_mon, current_day, current_ymd)
+
+    ! Run dnwm
+    call dnwm_comp_run(gcomp, exportstate, current_ymd, current_tod, restart_write=.false., rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Add scalars to export state. The direct NWM->OCN (SCHISM) connector does NOT
+    ! consume cpl_scalars (only the CMEPS mediator does), so that field is left
+    ! unconnected and dshr_fldlist_realize never realizes it. Guard the SetScalar
+    ! calls on its actual presence so dnwm does not abort with ESMF "Bad Object"
+    ! (ESMF_FieldGet on an uncreated field) when coupling directly to SCHISM.
+    if (flds_scalar_num > 0) then
+       ! Only set cpl_scalars when it is actually connected (and therefore realized).
+       ! The CMEPS mediator consumes cpl_scalars (mediator route), but the direct
+       ! NWM->OCN (SCHISM) connector does not, leaving it an unrealized advertised
+       ! placeholder; calling dshr_state_SetScalar on that aborts with ESMF
+       ! "Object being used before creation - Bad Object". NUOPC_IsConnected is the
+       ! correct route-agnostic guard (a present-but-unrealized placeholder is still
+       ! reported unconnected).
+       if (NUOPC_IsConnected(exportState, fieldName=trim(flds_scalar_name), rc=rc)) then
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call dshr_state_SetScalar(dble(nx_global),flds_scalar_index_nx, exportState, flds_scalar_name, flds_scalar_num, rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call dshr_state_SetScalar(dble(ny_global),flds_scalar_index_ny, exportState, flds_scalar_name, flds_scalar_num, rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       end if
+    end if
+
+   end subroutine InitializeRealize
+
+  !===============================================================================
+  subroutine ModelAdvance(gcomp, rc)
+
+    ! input/output variables
+    type(ESMF_GridComp)  :: gcomp
+    integer, intent(out) :: rc
+
+    ! local variables
+    type(ESMF_State)        :: importState, exportState
+    type(ESMF_Clock)        :: clock
+    type(ESMF_TimeInterval) :: timeStep
+    type(ESMF_Time)         :: currTime, nextTime
+    integer                 :: next_ymd      ! model date
+    integer                 :: next_tod      ! model sec into model date
+    integer                 :: yr            ! year
+    integer                 :: mon           ! month
+    integer                 :: day           ! day in month
+    logical                 :: restart_write ! restart alarm is ringing
+    character(len=*),parameter :: subname=trim(modName)//':(ModelAdvance) '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call memcheck(subname, 5, mainproc)
+    call shr_log_setLogUnit(logunit)
+    ! query the Component for its clock, importState and exportState
+    call NUOPC_ModelGet(gcomp, modelClock=clock, importState=importState, exportState=exportState, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! For nuopc - the component clock is advanced at the end of the time interval
+    ! For these to match for now - need to advance nuopc one timestep ahead for
+    ! shr_strdata time interpolation
+    call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    nextTime = currTime + timeStep
+    call ESMF_TimeGet( nextTime, yy=yr, mm=mon, dd=day, s=next_tod, rc=rc )
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call shr_cal_ymd2date(yr, mon, day, next_ymd)
+
+    ! write restart if alarm is ringing
+    restart_write = dshr_check_restart_alarm(clock, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! run dnwm
+    call dnwm_comp_run(gcomp, exportState, next_ymd, next_tod, restart_write, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+  end subroutine ModelAdvance
+
+  !===============================================================================
+  subroutine dnwm_comp_run(gcomp, exportState, target_ymd, target_tod, restart_write, rc)
+
+    ! --------------------------
+    ! advance dnwm
+    ! --------------------------
+
+    ! input/output variables:
+    type(ESMF_GridComp), intent(in)  :: gcomp
+    type(ESMF_State) , intent(inout) :: exportState
+    integer          , intent(in)    :: target_ymd       ! model date
+    integer          , intent(in)    :: target_tod       ! model sec into model date
+    logical          , intent(in)    :: restart_write
+    integer          , intent(out)   :: rc
+
+    ! local variables
+    logical :: first_time = .true.
+    integer :: n
+    character(len=CL) :: rpfile
+    character(*), parameter :: subName = "(dnwm_comp_run) "
+    !-------------------------------------------------------------------------------
+
+    call ESMF_TraceRegionEnter('DNWM_RUN')
+
+    !--------------------
+    ! First time initialization
+    !--------------------
+
+    if (first_time) then
+       ! Initialize dfields
+       call dshr_dfield_add(dfields, sdat, trim(fldname_river), trim(fldname_river), exportState, logunit, mainproc, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       ! Initialize module ponters
+       call dshr_state_getfldptr(exportState, trim(fldname_river) , fldptr1=river_volume_flux , rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+       ! Read restart if needed
+       if (restart_read .and. .not. skip_restart_read) then
+          call shr_get_rpointer_name(gcomp, 'nwm', target_ymd, target_tod, rpfile, 'read', rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call dshr_restart_read(restfilm, rpfile, logunit, my_task, mpicom, sdat, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+       end if
+
+       first_time = .false.
+    end if
+
+    !--------------------
+    ! advance dnwm streams and update export state
+    !--------------------
+
+    ! time and spatially interpolate to model time and grid
+    call ESMF_TraceRegionEnter('dnwm_strdata_advance')
+    call shr_strdata_advance(sdat, target_ymd, target_tod, logunit, 'dnwm', rc=rc)
+    call ESMF_TraceRegionExit('dnwm_strdata_advance')
+
+    ! copy all fields from streams to export state as default
+    ! This automatically will update the fields in the export state
+    call ESMF_TraceRegionEnter('dnwm_dfield_copy')
+    call dshr_dfield_copy(dfields,  sdat, rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_TraceRegionExit('dnwm_dfield_copy')
+
+    ! determine data model behavior based on the mode
+    call ESMF_TraceRegionEnter('dnwm_datamode')
+    select case (trim(datamode))
+    case('copyall')
+       ! zero out "special values" and any negative discharge of the export field
+       ! (NWM streamflow is non-negative; clamp defensively)
+       do n = 1, size(river_volume_flux)
+          if (abs(river_volume_flux(n)) > 1.0e28) river_volume_flux(n) = 0.0_r8
+          if (river_volume_flux(n) < 0.0_r8)      river_volume_flux(n) = 0.0_r8
+       enddo
+    end select
+
+    ! write restarts if needed
+    if (restart_write) then
+       if(trim(datamode) .eq. 'copyall') then
+          call shr_get_rpointer_name(gcomp, 'nwm', target_ymd, target_tod, rpfile, 'write', rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          call dshr_restart_write(rpfile, case_name, 'dnwm', inst_suffix, target_ymd, target_tod, &
+               logunit, my_task, sdat, rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       endif
+    end if
+
+    ! write diagnostics
+    if (diagnose_data) then
+       call dshr_state_diagnose(exportState, flds_scalar_name, subname//':ES',rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    end if
+
+    call ESMF_TraceRegionExit('dnwm_datamode')
+    call ESMF_TraceRegionExit('DNWM_RUN')
+
+  end subroutine dnwm_comp_run
+
+  !===============================================================================
+  subroutine ModelFinalize(gcomp, rc)
+    type(ESMF_GridComp)  :: gcomp
+    integer, intent(out) :: rc
+    rc = ESMF_SUCCESS
+    if (mainproc) then
+       write(logunit,*)
+       write(logunit,*) 'dnwm : end of main integration loop'
+       write(logunit,*)
+    end if
+  end subroutine ModelFinalize
+
+#ifdef CESMCOUPLED
+end module nwm_comp_nuopc
+#else
+end module cdeps_dnwm_comp
+#endif

--- a/dnwm/nwm_comp_nuopc.F90
+++ b/dnwm/nwm_comp_nuopc.F90
@@ -16,14 +16,12 @@ module cdeps_dnwm_comp
   ! gridded area-flux regrid). Mirrors DROF's datamode='copyall' passthrough.
   !----------------------------------------------------------------------------
   use ESMF             , only : ESMF_VM, ESMF_VMBroadcast, ESMF_GridCompGet
-  use ESMF             , only : ESMF_Mesh, ESMF_GridComp, ESMF_Time, ESMF_TimeInterval
+  use ESMF             , only : ESMF_Mesh, ESMF_GridComp, ESMF_Time
   use ESMF             , only : ESMF_State, ESMF_Clock, ESMF_SUCCESS, ESMF_LOGMSG_INFO
   use ESMF             , only : ESMF_TraceRegionEnter, ESMF_TraceRegionExit
-  use ESMF             , only : ESMF_Alarm, ESMF_METHOD_INITIALIZE, ESMF_MethodAdd, ESMF_MethodRemove
+  use ESMF             , only : ESMF_METHOD_INITIALIZE, ESMF_MethodRemove
   use ESMF             , only : ESMF_TimeGet, ESMF_ClockGet, ESMF_GridCompSetEntryPoint
-  use ESMF             , only : ESMF_ClockGetAlarm, ESMF_AlarmIsRinging, ESMF_AlarmRingerOff
   use ESMF             , only : operator(+), ESMF_LogWrite
-  use ESMF             , only : ESMF_StateGet, ESMF_StateItem_Flag, ESMF_STATEITEM_FIELD, operator(==)
   use NUOPC            , only : NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
   use NUOPC            , only : NUOPC_CompAttributeGet, NUOPC_Advertise, NUOPC_IsConnected
   use NUOPC            , only : NUOPC_FieldDictionaryHasEntry, NUOPC_FieldDictionaryAddEntry
@@ -33,12 +31,11 @@ module cdeps_dnwm_comp
   use NUOPC_Model      , only : model_label_SetRunClock => label_SetRunClock
   use NUOPC_Model      , only : model_label_Finalize    => label_Finalize
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
-  use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_const_mod    , only : SHR_CONST_SPVAL
+  use shr_kind_mod     , only : r8=>shr_kind_r8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_cal_mod      , only : shr_cal_ymd2date
   use shr_log_mod      , only : shr_log_setLogUnit, shr_log_error
   use dshr_methods_mod , only : dshr_state_getfldptr, dshr_state_diagnose, chkerr, memcheck
-  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_advance, shr_strdata_get_stream_domain
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_advance
   use dshr_strdata_mod , only : shr_strdata_init_from_config
   use dshr_mod         , only : dshr_model_initphase, dshr_init
   use dshr_mod         , only : dshr_state_setscalar, dshr_set_runclock, dshr_check_restart_alarm
@@ -184,6 +181,8 @@ contains
     character(*)    ,parameter :: F02 = "('(" // trim(modName) // ") ',a,l6)"
     !-------------------------------------------------------------------------------
 
+    logical :: isPresent
+
     namelist / dnwm_nml / datamode, model_meshfile, model_maskfile, &
          restfilm, nx_global, ny_global, skip_restart_read, export_all
 
@@ -262,7 +261,9 @@ contains
 
     ! river_volume_flux is not a CF/standard NUOPC field; register it (m3 s-1
     ! volumetric discharge) so it can be advertised, realized and connected.
-    if (.not. NUOPC_FieldDictionaryHasEntry(trim(fldname_river), rc=rc)) then
+    isPresent = NUOPC_FieldDictionaryHasEntry(trim(fldname_river), rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (.not. isPresent) then
        call NUOPC_FieldDictionaryAddEntry(trim(fldname_river), "m3 s-1", rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
@@ -291,7 +292,7 @@ contains
 
     ! local variables
     type(ESMF_TIME) :: currTime
-    type(ESMF_StateItem_Flag) :: itemtype_scalar  ! presence of cpl_scalars in exportState
+    logical         :: connected    ! cpl_scalars connected on this route?
     integer         :: current_ymd  ! model date
     integer         :: current_year ! model year
     integer         :: current_mon  ! model month
@@ -348,8 +349,9 @@ contains
        ! "Object being used before creation - Bad Object". NUOPC_IsConnected is the
        ! correct route-agnostic guard (a present-but-unrealized placeholder is still
        ! reported unconnected).
-       if (NUOPC_IsConnected(exportState, fieldName=trim(flds_scalar_name), rc=rc)) then
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       connected = NUOPC_IsConnected(exportState, fieldName=trim(flds_scalar_name), rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       if (connected) then
           call dshr_state_SetScalar(dble(nx_global),flds_scalar_index_nx, exportState, flds_scalar_name, flds_scalar_num, rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
           call dshr_state_SetScalar(dble(ny_global),flds_scalar_index_ny, exportState, flds_scalar_name, flds_scalar_num, rc)
@@ -378,10 +380,9 @@ contains
     ! local variables
     type(ESMF_State)        :: importState, exportState
     type(ESMF_Clock)        :: clock
-    type(ESMF_TimeInterval) :: timeStep
-    type(ESMF_Time)         :: currTime, nextTime
-    integer                 :: next_ymd      ! model date
-    integer                 :: next_tod      ! model sec into model date
+    type(ESMF_Time)         :: currTime
+    integer                 :: current_ymd   ! model date at the CURRENT time
+    integer                 :: current_tod   ! model sec into model date at the CURRENT time
     integer                 :: yr            ! year
     integer                 :: mon           ! month
     integer                 :: day           ! day in month
@@ -408,16 +409,16 @@ contains
     ! value consistent with its currTime stamp.
     call ESMF_ClockGet( clock, currTime=currTime, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeGet( currTime, yy=yr, mm=mon, dd=day, s=next_tod, rc=rc )
+    call ESMF_TimeGet( currTime, yy=yr, mm=mon, dd=day, s=current_tod, rc=rc )
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_cal_ymd2date(yr, mon, day, next_ymd)
+    call shr_cal_ymd2date(yr, mon, day, current_ymd)
 
     ! write restart if alarm is ringing
     restart_write = dshr_check_restart_alarm(clock, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! run dnwm
-    call dnwm_comp_run(gcomp, exportState, next_ymd, next_tod, restart_write, rc=rc)
+    call dnwm_comp_run(gcomp, exportState, current_ymd, current_tod, restart_write, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Stamp the export fields with the component clock's CURRENT time. On the direct
@@ -425,8 +426,8 @@ contains
     ! the connector copies the export field AND its timestamp to SCHISM's import; if
     ! the stamp does not match SCHISM's currTime, NUOPC aborts at run with
     ! "Import Fields not at current time" (NUOPC_ModelBase INCOMPATIBILITY). dnwm
-    ! interpolates its stream to next_time for the zero-order hold, but for the
-    ! coupler the value is valid AT currTime, so stamp with currTime.
+    ! interpolates its stream AT currTime (see above), so the exported value and
+    ! its timestamp agree by construction.
     call NUOPC_SetTimestamp(exportState, clock, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -450,6 +451,8 @@ contains
     ! local variables
     logical :: first_time = .true.
     integer :: n
+    integer :: n_spval        ! special/fill values clamped to 0 this advance
+    integer :: n_neg          ! negative discharge values clamped to 0 this advance
     character(len=CL) :: rpfile
     character(*), parameter :: subName = "(dnwm_comp_run) "
     !-------------------------------------------------------------------------------
@@ -487,6 +490,7 @@ contains
     ! time and spatially interpolate to model time and grid
     call ESMF_TraceRegionEnter('dnwm_strdata_advance')
     call shr_strdata_advance(sdat, target_ymd, target_tod, logunit, 'dnwm', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_TraceRegionExit('dnwm_strdata_advance')
 
     ! copy all fields from streams to export state as default
@@ -501,22 +505,34 @@ contains
     select case (trim(datamode))
     case('copyall')
        ! zero out "special values" and any negative discharge of the export field
-       ! (NWM streamflow is non-negative; clamp defensively)
+       ! (NWM streamflow is non-negative). Anything clamped is REPORTED: silently
+       ! altering data in a pass-through component would mask upstream sign or
+       ! reach-pairing bugs as mysteriously dry rivers.
+       n_spval = 0
+       n_neg   = 0
        do n = 1, size(river_volume_flux)
-          if (abs(river_volume_flux(n)) > 1.0e28) river_volume_flux(n) = 0.0_r8
-          if (river_volume_flux(n) < 0.0_r8)      river_volume_flux(n) = 0.0_r8
+          if (abs(river_volume_flux(n)) > 1.0e28_r8) then
+             river_volume_flux(n) = 0.0_r8
+             n_spval = n_spval + 1
+          else if (river_volume_flux(n) < 0.0_r8) then
+             river_volume_flux(n) = 0.0_r8
+             n_neg = n_neg + 1
+          end if
        enddo
+       if (n_spval > 0 .or. n_neg > 0) then
+          write(logunit,'(a,i8,a,i8,a)') trim(subname)//' WARNING: clamped ', n_spval, &
+               ' special/fill value(s) and ', n_neg, ' negative discharge value(s) to 0'
+       end if
     end select
 
-    ! write restarts if needed
+    ! write restarts if needed (datamode is validated to 'copyall' at advertise,
+    ! so no per-mode gate is required here)
     if (restart_write) then
-       if(trim(datamode) .eq. 'copyall') then
-          call shr_get_rpointer_name(gcomp, 'nwm', target_ymd, target_tod, rpfile, 'write', rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-          call dshr_restart_write(rpfile, case_name, 'dnwm', inst_suffix, target_ymd, target_tod, &
-               logunit, my_task, sdat, rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       endif
+       call shr_get_rpointer_name(gcomp, 'nwm', target_ymd, target_tod, rpfile, 'write', rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call dshr_restart_write(rpfile, case_name, 'dnwm', inst_suffix, target_ymd, target_tod, &
+            logunit, my_task, sdat, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if
 
     ! write diagnostics

--- a/dnwm/nwm_comp_nuopc.F90
+++ b/dnwm/nwm_comp_nuopc.F90
@@ -27,6 +27,7 @@ module cdeps_dnwm_comp
   use NUOPC            , only : NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
   use NUOPC            , only : NUOPC_CompAttributeGet, NUOPC_Advertise, NUOPC_IsConnected
   use NUOPC            , only : NUOPC_FieldDictionaryHasEntry, NUOPC_FieldDictionaryAddEntry
+  use NUOPC            , only : NUOPC_SetTimestamp
   use NUOPC_Model      , only : model_routine_SS        => SetServices
   use NUOPC_Model      , only : model_label_Advance     => label_Advance
   use NUOPC_Model      , only : model_label_SetRunClock => label_SetRunClock
@@ -356,6 +357,15 @@ contains
        end if
     end if
 
+    ! Stamp the export with the clock's initial time so the export field is valid
+    ! AT the start time. On the direct NWM->OCN connector, OCN's run phase checks
+    ! import fields are at currTime at the FIRST step -- before dnwm's ModelAdvance
+    ! runs -- so without an init-time stamp the field carries no/initial timestamp
+    ! and NUOPC aborts "Import Fields not at current time". (NUOPC_SetTimestamp in
+    ! ModelAdvance keeps it current on subsequent steps.)
+    call NUOPC_SetTimestamp(exportState, clock, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
    end subroutine InitializeRealize
 
   !===============================================================================
@@ -403,6 +413,16 @@ contains
 
     ! run dnwm
     call dnwm_comp_run(gcomp, exportState, next_ymd, next_tod, restart_write, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Stamp the export fields with the component clock's CURRENT time. On the direct
+    ! NWM->OCN connector (no CMEPS mediator to broker time via label_TimestampExport)
+    ! the connector copies the export field AND its timestamp to SCHISM's import; if
+    ! the stamp does not match SCHISM's currTime, NUOPC aborts at run with
+    ! "Import Fields not at current time" (NUOPC_ModelBase INCOMPATIBILITY). dnwm
+    ! interpolates its stream to next_time for the zero-order hold, but for the
+    ! coupler the value is valid AT currTime, so stamp with currTime.
+    call NUOPC_SetTimestamp(exportState, clock, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine ModelAdvance

--- a/dnwm/nwm_comp_nuopc.F90
+++ b/dnwm/nwm_comp_nuopc.F90
@@ -16,7 +16,7 @@ module cdeps_dnwm_comp
   ! gridded area-flux regrid). Mirrors DROF's datamode='copyall' passthrough.
   !----------------------------------------------------------------------------
   use ESMF             , only : ESMF_VM, ESMF_VMBroadcast, ESMF_GridCompGet
-  use ESMF             , only : ESMF_Mesh, ESMF_GridComp, ESMF_Time
+  use ESMF             , only : ESMF_Mesh, ESMF_GridComp, ESMF_Time, ESMF_TimeInterval
   use ESMF             , only : ESMF_State, ESMF_Clock, ESMF_SUCCESS, ESMF_LOGMSG_INFO
   use ESMF             , only : ESMF_TraceRegionEnter, ESMF_TraceRegionExit
   use ESMF             , only : ESMF_METHOD_INITIALIZE, ESMF_MethodRemove
@@ -84,6 +84,12 @@ module cdeps_dnwm_comp
   integer                      :: ny_global
   logical                      :: skip_restart_read = .false.         ! true => skip restart read
   logical                      :: export_all = .false.                ! true => export all fields, do not check connected or not
+  logical                      :: advance_to_next_time = .false.      ! stream interpolation target: .false. => currTime
+                                                                      ! (direct NWM->OCN connector, the validated route: the
+                                                                      ! consumer holds the value over [t,t+dt], so the export
+                                                                      ! must be valid at the window START); .true. => the
+                                                                      ! standard CDEPS next-time convention for runs where a
+                                                                      ! mediator consumes the export at a later phase
 
   logical                      :: diagnose_data = .true.
   integer      , parameter     :: main_task=0                       ! task number of main task
@@ -174,7 +180,7 @@ contains
     integer           :: ierr       ! error code
     type(fldlist_type), pointer :: fldList
     type(ESMF_VM)     :: vm
-    integer :: bcasttmp(4)
+    integer :: bcasttmp(5)
     character(len=*),parameter :: subname=trim(modName)//':(InitializeAdvertise) '
     character(*)    ,parameter :: F00 = "('(" // trim(modName) // ") ',8a)"
     character(*)    ,parameter :: F01 = "('(" // trim(modName) // ") ',a,2x,i8)"
@@ -184,7 +190,8 @@ contains
     logical :: isPresent
 
     namelist / dnwm_nml / datamode, model_meshfile, model_maskfile, &
-         restfilm, nx_global, ny_global, skip_restart_read, export_all
+         restfilm, nx_global, ny_global, skip_restart_read, export_all, &
+         advance_to_next_time
 
     rc = ESMF_SUCCESS
 
@@ -194,6 +201,12 @@ contains
     ! Obtain flds_scalar values, mpi values, multi-instance values and
     ! set logunit and set shr logging to my log file. DNWM plays the runoff
     ! (ROF) role in the coupled system, so reuse the 'ROF' component string.
+    ! DELIBERATE IDENTITY CHOICE with two consequences to know: (1) the dshr
+    ! default log name becomes d<rof>.log = drof.log -- set the 'logfile'
+    ! component attribute (e.g. logfile = dnwm.log in the run config) for a
+    ! distinct log; (2) PIO settings are keyed to ROF, so running dnwm and a
+    ! real drof in the same executable is NOT supported. Restart pointer files
+    ! use the distinct 'nwm' token (rpointer.nwm.*), see dnwm_comp_run.
     call dshr_init(gcomp, 'ROF', mpicom, my_task, inst_index, inst_suffix, &
          flds_scalar_name, flds_scalar_num, flds_scalar_index_nx, flds_scalar_index_ny, &
          logunit, rc=rc)
@@ -224,11 +237,13 @@ contains
        write(logunit,F00)' restfilm = ',trim(restfilm)
        write(logunit,F02)' skip_restart_read = ',skip_restart_read
        write(logunit,F02)' export_all = ', export_all
+       write(logunit,F02)' advance_to_next_time = ', advance_to_next_time
        bcasttmp = 0
        bcasttmp(1) = nx_global
        bcasttmp(2) = ny_global
        if(skip_restart_read) bcasttmp(3) = 1
        if(export_all) bcasttmp(4) = 1
+       if(advance_to_next_time) bcasttmp(5) = 1
     end if
 
     ! broadcast namelist input
@@ -243,13 +258,14 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call ESMF_VMBroadcast(vm, restfilm, CL, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMBroadcast(vm, bcasttmp, 4, main_task, rc=rc)
+    call ESMF_VMBroadcast(vm, bcasttmp, 5, main_task, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     nx_global = bcasttmp(1)
     ny_global = bcasttmp(2)
     skip_restart_read = (bcasttmp(3) == 1)
     export_all = (bcasttmp(4) == 1)
+    advance_to_next_time = (bcasttmp(5) == 1)
 
     ! Validate datamode
     if (trim(datamode) == 'copyall') then
@@ -333,7 +349,8 @@ contains
     call shr_cal_ymd2date(current_year, current_mon, current_day, current_ymd)
 
     ! Run dnwm
-    call dnwm_comp_run(gcomp, exportstate, current_ymd, current_tod, restart_write=.false., rc=rc)
+    call dnwm_comp_run(gcomp, exportstate, current_ymd, current_tod, current_ymd, current_tod, &
+         restart_write=.false., rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Add scalars to export state. The direct NWM->OCN (SCHISM) connector does NOT
@@ -380,9 +397,12 @@ contains
     ! local variables
     type(ESMF_State)        :: importState, exportState
     type(ESMF_Clock)        :: clock
-    type(ESMF_Time)         :: currTime
-    integer                 :: current_ymd   ! model date at the CURRENT time
-    integer                 :: current_tod   ! model sec into model date at the CURRENT time
+    type(ESMF_TimeInterval) :: timeStep
+    type(ESMF_Time)         :: currTime, nextTime
+    integer                 :: interp_ymd    ! stream interpolation target date
+    integer                 :: interp_tod    ! stream interpolation target sec
+    integer                 :: next_ymd      ! window-end date (restart naming, CDEPS convention)
+    integer                 :: next_tod      ! window-end sec
     integer                 :: yr            ! year
     integer                 :: mon           ! month
     integer                 :: day           ! day in month
@@ -398,27 +418,40 @@ contains
     call NUOPC_ModelGet(gcomp, modelClock=clock, importState=importState, exportState=exportState, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! One-way direct NWM->OCN connector: there is no CMEPS mediator to broker time.
-    ! SCHISM applies the imported discharge as a zero-order hold over its current
-    ! step [currTime, currTime+dt] and the export is stamped with currTime (below),
-    ! so interpolate the stream AT currTime -- not currTime+timeStep. The CDEPS dshr
-    ! default reads one step ahead because the mediator schedule consumes the data at
-    ! a later phase; on this mediator-less route that lead would inject the NEXT
-    ! interval's flow one step early -- invisible to a constant-discharge test, but a
-    ! ramping hydrograph would show the offset. Reading currTime keeps the exported
-    ! value consistent with its currTime stamp.
-    call ESMF_ClockGet( clock, currTime=currTime, rc=rc)
+    ! Stream interpolation target. Default (advance_to_next_time=.false., the
+    ! validated direct NWM->OCN route): there is no CMEPS mediator to broker time;
+    ! the consumer applies the imported discharge as a zero-order hold over its
+    ! current step [currTime, currTime+dt] and the export is stamped with currTime
+    ! (below), so interpolate the stream AT currTime. The standard CDEPS convention
+    ! reads one step ahead because a mediator schedule consumes the data at a later
+    ! phase; on the mediator-less route that lead would inject the NEXT interval's
+    ! flow one step early -- invisible to a constant-discharge test, exposed by a
+    ! ramping hydrograph. Set advance_to_next_time=.true. (namelist) to restore the
+    ! next-time convention when a mediator consumes this export.
+    call ESMF_ClockGet( clock, currTime=currTime, timeStep=timeStep, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_TimeGet( currTime, yy=yr, mm=mon, dd=day, s=current_tod, rc=rc )
+    nextTime = currTime + timeStep
+    call ESMF_TimeGet( nextTime, yy=yr, mm=mon, dd=day, s=next_tod, rc=rc )
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call shr_cal_ymd2date(yr, mon, day, current_ymd)
+    call shr_cal_ymd2date(yr, mon, day, next_ymd)
+    if (advance_to_next_time) then
+       interp_ymd = next_ymd
+       interp_tod = next_tod
+    else
+       call ESMF_TimeGet( currTime, yy=yr, mm=mon, dd=day, s=interp_tod, rc=rc )
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       call shr_cal_ymd2date(yr, mon, day, interp_ymd)
+    end if
 
     ! write restart if alarm is ringing
     restart_write = dshr_check_restart_alarm(clock, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! run dnwm
-    call dnwm_comp_run(gcomp, exportState, current_ymd, current_tod, restart_write, rc=rc)
+    ! run dnwm. Restart artifacts are always named at the window END (next_ymd/tod),
+    ! the CDEPS convention: a continued run resumes at that time and looks for
+    ! rpointer files stamped with it, independent of the interpolation target.
+    call dnwm_comp_run(gcomp, exportState, interp_ymd, interp_tod, next_ymd, next_tod, &
+         restart_write, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Stamp the export fields with the component clock's CURRENT time. On the direct
@@ -434,7 +467,8 @@ contains
   end subroutine ModelAdvance
 
   !===============================================================================
-  subroutine dnwm_comp_run(gcomp, exportState, target_ymd, target_tod, restart_write, rc)
+  subroutine dnwm_comp_run(gcomp, exportState, target_ymd, target_tod, restart_ymd, restart_tod, &
+       restart_write, rc)
 
     ! --------------------------
     ! advance dnwm
@@ -443,8 +477,10 @@ contains
     ! input/output variables:
     type(ESMF_GridComp), intent(in)  :: gcomp
     type(ESMF_State) , intent(inout) :: exportState
-    integer          , intent(in)    :: target_ymd       ! model date
-    integer          , intent(in)    :: target_tod       ! model sec into model date
+    integer          , intent(in)    :: target_ymd       ! stream interpolation target date
+    integer          , intent(in)    :: target_tod       ! stream interpolation target sec
+    integer          , intent(in)    :: restart_ymd      ! restart naming date (window end)
+    integer          , intent(in)    :: restart_tod      ! restart naming sec (window end)
     logical          , intent(in)    :: restart_write
     integer          , intent(out)   :: rc
 
@@ -528,9 +564,9 @@ contains
     ! write restarts if needed (datamode is validated to 'copyall' at advertise,
     ! so no per-mode gate is required here)
     if (restart_write) then
-       call shr_get_rpointer_name(gcomp, 'nwm', target_ymd, target_tod, rpfile, 'write', rc)
+       call shr_get_rpointer_name(gcomp, 'nwm', restart_ymd, restart_tod, rpfile, 'write', rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       call dshr_restart_write(rpfile, case_name, 'dnwm', inst_suffix, target_ymd, target_tod, &
+       call dshr_restart_write(rpfile, case_name, 'dnwm', inst_suffix, restart_ymd, restart_tod, &
             logunit, my_task, sdat, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     end if


### PR DESCRIPTION
## What

Adds `dnwm`, a CDEPS data component that reads a National Water Model discharge stream and exports a single field, `river_volume_flux` (m^3 s-1), one value per unstructured-mesh element. It is the data-ingestion half of one-way NWM -> ocean river forcing for the coastal application (used with a companion ufs-weather-model wiring PR; addresses the data-ingestion portion of ufs-weather-model's NWM coupling roadmap).

## Design

- Cloned from `drof` and kept deliberately minimal: `datamode = "copyall"` passthrough of an element-indexed stream. The component knows nothing about reaches or hydrology - the reach-to-element mapping is done offline; dnwm is a faithful transport.

- Keeps the ROF identity (`dshr_init(gcomp, 'ROF', ...)`) so a future CMEPS mediator route
  (ROF -> MED -> OCN) is a drop-in.

- The exchange downstream is `remapMethod=redist` under an element-id contract (stream/mesh element order == ocean-model global element ids), so the exported field is volumetric m^3/s with no area-flux conversion anywhere.


- Stream interpolation target: by default the stream is read AT the current time - on the mediator-less direct connector the consumer holds the value over [t, t+dt], so the export must be valid at the window start. A namelist option `advance_to_next_time = .true.` restores the standard CDEPS next-time convention for configurations where a mediator consumes the export at a later phase. Restart artifacts are always named at the window end (the CDEPS convention a continued run resumes from), independent of the interpolation target.

- Fill values and negative discharge are clamped to zero; every clamp is counted and reported to the component log (never silent).

